### PR TITLE
Remove invalid reference link from keywords.txt

### DIFF
--- a/keywords.txt
+++ b/keywords.txt
@@ -1,11 +1,11 @@
 # LITERAL1 specifies constants
 
 # KEYWORD1 specifies datatypes and C/C++ keywords
-AdaEncoder	KEYWORD1	AdaEncoder
+AdaEncoder	KEYWORD1
 
 # KEYWORD2 specifies methods and functions
-addEncoder	KEYWORD2	AddEncoder
+addEncoder	KEYWORD2
 attachInterrupt	KEYWORD2	AttachInterrupt
-encoderInterrupt KEYWORD2	encoderInterrupt
-turnOffPWM	KEYWORD2	turnOffPWM
-genie		KEYWORD2	Genie
+encoderInterrupt KEYWORD2
+turnOffPWM	KEYWORD2
+genie		KEYWORD2


### PR DESCRIPTION
The third field of keywords.txt is used to provide Arduino Language Reference links, which are accessed from the Arduino IDE by highlighting the keyword and then selecting "Find in Reference" from the Help or right click menu. Adding values to this field that do not match any existing reference pages results in a "Could not open the URL" error.

Reference:
https://github.com/arduino/Arduino/wiki/Arduino-IDE-1.5:-Library-specification#keywordstxt-format